### PR TITLE
Warning fix / Exposed full screen toggle to public

### DIFF
--- a/GUIPlayerView/Classes/GUIPlayerView.h
+++ b/GUIPlayerView/Classes/GUIPlayerView.h
@@ -37,6 +37,7 @@
 - (void)play;
 - (void)pause;
 - (void)stop;
+- (void)toggleFullscreen;
 
 - (BOOL)isPlaying;
 

--- a/GUIPlayerView/Classes/GUIPlayerView.m
+++ b/GUIPlayerView/Classes/GUIPlayerView.m
@@ -451,23 +451,22 @@
     [self stop];
   }
   
-  player = [[AVPlayer alloc] initWithPlayerItem:nil];
-  
   AVURLAsset *asset = [[AVURLAsset alloc] initWithURL:videoURL options:nil];
   NSArray *keys = [NSArray arrayWithObject:@"playable"];
-  
-    __weak typeof(self) weakSelf = self;
+  AVPlayerItem *playerItem = [[AVPlayerItem alloc] initWithAsset:asset];
+  player = [[AVPlayer alloc] initWithPlayerItem: playerItem];
+
   [asset loadValuesAsynchronouslyForKeys:keys completionHandler:^{
-    weakSelf.currentItem = [AVPlayerItem playerItemWithAsset:asset];
-    [weakSelf.player replaceCurrentItemWithPlayerItem:weakSelf.currentItem];
-    
-    if (playAutomatically) {
-      dispatch_sync(dispatch_get_main_queue(), ^{
-        [weakSelf play];
-      });
-    }
+	  currentItem = [AVPlayerItem playerItemWithAsset:asset];
+	  [player replaceCurrentItemWithPlayerItem:currentItem];
+
+	  if (playAutomatically) {
+			dispatch_sync(dispatch_get_main_queue(), ^{
+				[self play];
+			});
+	  }
   }];
-  
+	
   [player setAllowsExternalPlayback:YES];
   playerLayer = [AVPlayerLayer playerLayerWithPlayer:player];
   [self.layer addSublayer:playerLayer];

--- a/GUIPlayerView/Classes/GUIPlayerView.m
+++ b/GUIPlayerView/Classes/GUIPlayerView.m
@@ -537,6 +537,10 @@
   }
 }
 
+- (void)toggleFullscreen {
+  [self toggleFullscreen:fullscreenButton];
+}
+
 - (void)stop {
   if (player) {
     [player pause];


### PR DESCRIPTION
It would be handy to call full screen toggle when device rotates

```
 override func didRotateFromInterfaceOrientation(fromInterfaceOrientation: UIInterfaceOrientation) {
      player.toggleFullscreen()
 }
```
